### PR TITLE
2021-11-10  RLS-2801 GUARD-2236 Inventory Sync Caching Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ build
 log
 *Credentials*.csv
 
+#Rider
+**/.idea/**

--- a/src/lightspeedAccess/Models/Product/LightspeedProduct.cs
+++ b/src/lightspeedAccess/Models/Product/LightspeedProduct.cs
@@ -128,6 +128,7 @@ namespace LightspeedAccess.Models.Product
 		public int ItemShopId{ get; set; }
 
 		[ XmlElement( "qoh" ) ]
+		[ DataMember( Order = 4 ) ]		//Needed for caching
 		public int QuantityOnHand{ get; set; }
 	}
 

--- a/src/lightspeedAccess/Properties/AssemblyInfo.cs
+++ b/src/lightspeedAccess/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]


### PR DESCRIPTION
- LightspeedProduct > ItemShop: added [ DataMember ] to QuantityOnHand since it's needed for caching on the app side. Wouldn't save it to cache otherwise
- Added Rider path to .gitignore
 
[v.1.2.1]